### PR TITLE
Replace `initializer...def load_console` with a simple `console do` block

### DIFF
--- a/lib/marco-polo.rb
+++ b/lib/marco-polo.rb
@@ -1,17 +1,12 @@
 module MarcoPolo
   class Railtie < Rails::Railtie
-    initializer "marco_polo.run_irb_config" do |app|
-      app.instance_eval do
-        def load_console(app=self)
-          super
-          ARGV.push "-r", File.join(File.dirname(__FILE__),
-                                    "marco-polo",
-                                    "marco-polo.irbrc.rb")
+    console do
+      ARGV.push "-r", File.join(File.dirname(__FILE__),
+                                "marco-polo",
+                                "marco-polo.irbrc.rb")
 
-          app_specific = File.join(Rails.root, ".irbrc.rb")
-          ARGV.push "-r", app_specific if File.exist? app_specific
-        end
-      end
+      app_specific = File.join(Rails.root, ".irbrc.rb")
+      ARGV.push "-r", app_specific if File.exist? app_specific
     end
   end
 end


### PR DESCRIPTION
`instance_eval` is a bit too hacky to my taste. There's more natural way
to handle this, namely the `::Rails::Railtie.console` method. It is not
quite well-documented, but it is public and does the job. It works
pretty much the same way as `.generators` and `.rake_tasks` methods
(those are documented).
- https://github.com/rails/rails/blob/v4.1.2.rc1/railties/lib/rails/railtie.rb#L141
- http://api.rubyonrails.org/classes/Rails/Railtie.html#method-i-generators

I tested this against my Rails 4.1.1 app.
