### PR TITLE
Rails 6.0.0 compatibility

### DIFF
--- a/lib/marco-polo/marco-polo.irbrc.rb
+++ b/lib/marco-polo/marco-polo.irbrc.rb
@@ -5,7 +5,7 @@ elsif Rails and Rails.env
 end
 
 if rails_env
-  current_app = ENV["MARCO_POLO_APP_NAME"] || Rails.application.class.parent_name.underscore.gsub("_", "-")
+  current_app = ENV["MARCO_POLO_APP_NAME"] || Rails.application.class.module_parent_name.underscore.gsub("_", "-")
 
   # shorten some common long environment names
   rails_env = "dev" if rails_env == "development"


### PR DESCRIPTION
Removes deprecation warning `Deprecated DEPRECATION WARNING: `Module#parent_name` has been renamed to `module_parent_name`. `parent_name` is deprecated and will be removed in Rails 6.1.`