### PR TITLE
Use Pry::Prompt API for Pry 0.13.0+ and suppress deprecation warning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+Unreleased Use Pry::Prompt API for Pry 0.13.0+
 2.0.1 Rails 6 support for Pry
 2.0.0 Rails 6 support
 1.2.1 Less hacky railtie

--- a/lib/marco-polo.rb
+++ b/lib/marco-polo.rb
@@ -12,18 +12,25 @@ module MarcoPolo
 end
 
 if defined? Pry
-  Pry.config.prompt = [
-    proc {
-      current_app = ENV["MARCO_POLO_APP_NAME"] || Rails.application.class.module_parent_name.underscore.gsub("_", "-")
-      rails_env = Rails.env.downcase
+  wait_proc = proc {
+    current_app = ENV["MARCO_POLO_APP_NAME"] || Rails.application.class.module_parent_name.underscore.gsub("_", "-")
+    rails_env = Rails.env.downcase
 
-      # shorten some common long environment names
-      rails_env = "dev" if rails_env == "development"
-      rails_env = "prod" if rails_env == "production"
+    # shorten some common long environment names
+    rails_env = "dev" if rails_env == "development"
+    rails_env = "prod" if rails_env == "production"
 
-      "#{current_app}(#{rails_env})> "
-    },
-    proc { "> "}
-  ]
+    "#{current_app}(#{rails_env})> "
+  }
+  incomplete_proc = proc { "> "}
+
+  if defined? Pry::Prompt
+    Pry.config.prompt = Pry::Prompt.new(
+      'marco-polo',
+      'A prompt which shows your app name and environment',
+      [wait_proc, incomplete_proc]
+    )
+  else
+    Pry.config.prompt = [wait_proc, incomplete_proc]
+  end
 end
-


### PR DESCRIPTION
With Pry 0.13.0 or above, following warning will be issued:
```
warning: setting prompt with help of `Pry.config.prompt = [proc {}, proc {}]` is deprecated. Use Pry::Prompt API instead
```

References:
* https://github.com/pry/pry/blob/master/CHANGELOG.md#api-changes
* https://github.com/pry/pry/pull/1877